### PR TITLE
Clippy lint 強制・unsafe SIGPIPE ハンドラ除去・cargo-deny CI 追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,27 @@ jobs:
 
       - name: Format check
         run: cargo fmt -- --check
+  security:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@56f84321dbccf38fb67ce29ab63e4754056677e0 # stable
+        with:
+          toolchain: stable
+
+      - name: Cache Cargo
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          cache-targets: false
+
+      - name: Install cargo-deny
+        run: cargo install cargo-deny --locked
+
+      - name: Deny check
+        run: cargo deny check

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,9 +79,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.1"
+version = "1.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -89,9 +89,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.38.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
 dependencies = [
  "cc",
  "cmake",
@@ -107,9 +107,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "bumpalo"
@@ -125,9 +125,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
-version = "1.2.57"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -155,9 +155,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -177,9 +177,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -195,9 +195,9 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cmake"
-version = "0.1.57"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
@@ -457,9 +457,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "heck"
@@ -520,9 +520,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -535,7 +535,6 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -543,15 +542,14 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http",
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -584,12 +582,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -597,9 +596,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -610,9 +609,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -624,15 +623,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -644,15 +643,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -686,9 +685,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -702,9 +701,9 @@ checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
-version = "0.7.10"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
 dependencies = [
  "memchr",
  "serde",
@@ -718,9 +717,9 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jni"
@@ -731,7 +730,7 @@ dependencies = [
  "cesu8",
  "cfg-if",
  "combine",
- "jni-sys",
+ "jni-sys 0.3.1",
  "log",
  "thiserror 1.0.69",
  "walkdir",
@@ -740,9 +739,31 @@ dependencies = [
 
 [[package]]
 name = "jni-sys"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "jobserver"
@@ -756,10 +777,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -772,15 +795,15 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "log"
@@ -808,9 +831,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
@@ -872,16 +895,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -977,9 +994,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
  "rand_core",
@@ -1089,15 +1106,15 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
@@ -1158,9 +1175,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -1398,9 +1415,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -1408,9 +1425,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -1423,9 +1440,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "a91135f59b1cbf38c91e73cf3386fca9bb77915c45ce2771460c9d92f0f3d776"
 dependencies = [
  "bytes",
  "libc",
@@ -1438,9 +1455,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1612,9 +1629,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1625,23 +1642,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.64"
+version = "0.4.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1649,9 +1662,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1662,18 +1675,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.91"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1691,9 +1704,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -1995,15 +2008,15 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -2012,9 +2025,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2024,18 +2037,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.42"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.42"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2044,18 +2057,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2071,9 +2084,9 @@ checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -2082,9 +2095,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -2093,9 +2106,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -822,7 +822,6 @@ name = "notch"
 version = "0.5.0"
 dependencies = [
  "clap",
- "libc",
  "reqwest",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,11 +15,29 @@ serde_json = "1.0.149"
 thiserror = "2.0.18"
 url = "2.5.8"
 
-[target.'cfg(unix)'.dependencies]
-libc = "0.2"
-
 [dev-dependencies]
 wiremock = "0.6.5"
+
+[lints.rust]
+unsafe_code = "forbid"
+
+[lints.clippy]
+# フルパス使用検出
+absolute_paths = "deny"
+# Rustイディオム (RUST.md idioms table)
+cast_possible_truncation = "deny"
+redundant_closure_for_method_calls = "deny"
+filter_map_next = "deny"
+flat_map_option = "deny"
+manual_filter_map = "deny"
+manual_find_map = "deny"
+# インポート
+wildcard_imports = "deny"
+enum_glob_use = "deny"
+# 文字列
+str_to_string = "deny"
+# 引数
+needless_pass_by_value = "deny"
 
 [profile.release]
 opt-level = 3

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,30 @@
+[advisories]
+version = 2
+ignore = []
+
+[licenses]
+version = 2
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "0BSD",
+    "Zlib",
+    "Unicode-3.0",
+    "CDLA-Permissive-2.0",
+    "BSL-1.0",
+    "MPL-2.0",
+    "Unlicense",
+]
+
+[bans]
+multiple-versions = "warn"
+wildcards = "allow"
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]

--- a/deny.toml
+++ b/deny.toml
@@ -18,6 +18,7 @@ allow = [
     "BSL-1.0",
     "MPL-2.0",
     "Unlicense",
+    "OpenSSL",
 ]
 
 [bans]

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,6 +1,10 @@
+use std::{env, io, time::Duration};
+
 use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION};
+use serde::de::DeserializeOwned;
 use serde_json::json;
 use thiserror::Error;
+use tokio::time::sleep;
 
 use crate::types::{
     DataSourceQueryResponse, DatabaseResponse, NotionErrorResponse, PageMarkdownResponse,
@@ -36,7 +40,7 @@ pub enum NotchError {
     InvalidInput(String),
 
     #[error("Failed to read stdin: {0}")]
-    Io(#[from] std::io::Error),
+    Io(#[from] io::Error),
 
     #[error(transparent)]
     Http(#[from] reqwest::Error),
@@ -50,12 +54,12 @@ pub struct Client {
 
 impl Client {
     pub fn new() -> Result<Self, NotchError> {
-        let token = std::env::var("NOTION_TOKEN").map_err(|_| NotchError::TokenNotSet)?;
-        Self::with_token(token, NOTION_API_BASE.to_string())
+        let token = env::var("NOTION_TOKEN").map_err(|_| NotchError::TokenNotSet)?;
+        Self::with_token(&token, NOTION_API_BASE.to_owned())
     }
 
     #[doc(hidden)]
-    pub fn with_token(token: String, base_url: String) -> Result<Self, NotchError> {
+    pub fn with_token(token: &str, base_url: String) -> Result<Self, NotchError> {
         let mut headers = HeaderMap::new();
         headers.insert(
             AUTHORIZATION,
@@ -69,7 +73,7 @@ impl Client {
         let http = reqwest::Client::builder()
             .default_headers(headers)
             .user_agent(concat!("notch/", env!("CARGO_PKG_VERSION")))
-            .timeout(std::time::Duration::from_secs(30))
+            .timeout(Duration::from_secs(30))
             .build()?;
 
         Ok(Self { http, base_url })
@@ -133,11 +137,11 @@ impl Client {
                         .and_then(|v| v.to_str().ok())
                         .and_then(|v| v.parse::<u64>().ok())
                         .unwrap_or(1);
-                    tokio::time::sleep(std::time::Duration::from_secs(wait)).await;
+                    sleep(Duration::from_secs(wait)).await;
                 }
                 500..=599 => {
                     let wait_ms = 100u64 << attempt; // 100ms, 200ms, 400ms
-                    tokio::time::sleep(std::time::Duration::from_millis(wait_ms)).await;
+                    sleep(Duration::from_millis(wait_ms)).await;
                 }
                 _ => return Ok(resp),
             }
@@ -145,7 +149,7 @@ impl Client {
         Ok(build_request().send().await?)
     }
 
-    async fn handle_response<T: serde::de::DeserializeOwned>(
+    async fn handle_response<T: DeserializeOwned>(
         &self,
         resp: reqwest::Response,
     ) -> Result<T, NotchError> {
@@ -160,7 +164,7 @@ impl Client {
             _ => {
                 let err: NotionErrorResponse = resp.json().await.unwrap_or(NotionErrorResponse {
                     status,
-                    code: "unknown".to_string(),
+                    code: "unknown".to_owned(),
                     message: format!("HTTP {status}"),
                 });
                 Err(NotchError::Api {
@@ -174,14 +178,14 @@ impl Client {
 
 pub fn parse_page_id(input: &str) -> Result<String, NotchError> {
     if is_uuid(input) {
-        return Ok(input.to_string());
+        return Ok(input.to_owned());
     }
 
     if is_hex32(input) {
         return Ok(format_uuid(input));
     }
 
-    let parsed = url::Url::parse(input).map_err(|_| NotchError::InvalidUrl(input.to_string()))?;
+    let parsed = url::Url::parse(input).map_err(|_| NotchError::InvalidUrl(input.to_owned()))?;
 
     let host = parsed.host_str().unwrap_or("");
     let is_notion = host == "notion.so"
@@ -189,14 +193,14 @@ pub fn parse_page_id(input: &str) -> Result<String, NotchError> {
         || host == "notion.site"
         || host.ends_with(".notion.site");
     if !is_notion {
-        return Err(NotchError::InvalidUrl(input.to_string()));
+        return Err(NotchError::InvalidUrl(input.to_owned()));
     }
 
     let path = parsed.path();
     let last_segment = path.rsplit('/').next().unwrap_or("");
 
     if is_uuid(last_segment) {
-        return Ok(last_segment.to_string());
+        return Ok(last_segment.to_owned());
     }
 
     if let Some(hex) = extract_hex32_suffix(last_segment) {
@@ -209,7 +213,7 @@ pub fn parse_page_id(input: &str) -> Result<String, NotchError> {
         }
     }
 
-    Err(NotchError::InvalidUrl(input.to_string()))
+    Err(NotchError::InvalidUrl(input.to_owned()))
 }
 
 fn is_uuid(s: &str) -> bool {
@@ -254,12 +258,14 @@ fn extract_hex32_suffix(s: &str) -> Option<&str> {
 mod tests {
     use super::*;
 
+    // T-041: parse_page_id — UUID 形式をそのまま返す
     #[test]
     fn test_parse_uuid_direct() {
         let id = "12345678-1234-1234-1234-123456789abc";
         assert_eq!(parse_page_id(id).unwrap(), id);
     }
 
+    // T-042: parse_page_id — 32桁 hex を UUID 形式に変換する
     #[test]
     fn test_parse_hex32() {
         let hex = "123456781234123412341234567890ab";
@@ -269,6 +275,7 @@ mod tests {
         );
     }
 
+    // T-043: parse_page_id — notion.so URL のタイトル付きパスから ID を抽出
     #[test]
     fn test_parse_notion_url_with_title() {
         let url = "https://www.notion.so/My-Page-Title-123456781234123412341234567890ab";
@@ -278,6 +285,7 @@ mod tests {
         );
     }
 
+    // T-044: parse_page_id — ワークスペース付き URL から ID を抽出
     #[test]
     fn test_parse_notion_url_with_workspace() {
         let url = "https://www.notion.so/workspace/123456781234123412341234567890ab";
@@ -287,6 +295,7 @@ mod tests {
         );
     }
 
+    // T-045: parse_page_id — クエリパラメータ ?p= から ID を抽出
     #[test]
     fn test_parse_notion_url_with_query_param() {
         let url = "https://www.notion.so/page?p=123456781234123412341234567890ab";
@@ -296,11 +305,13 @@ mod tests {
         );
     }
 
+    // T-046: parse_page_id — notion 以外のドメインはエラー
     #[test]
     fn test_parse_invalid_url() {
         assert!(parse_page_id("https://example.com/page").is_err());
     }
 
+    // T-047: parse_page_id — evil-notion.so など類似ドメインを拒否する
     #[test]
     fn test_parse_spoofed_domain_rejected() {
         assert!(
@@ -308,11 +319,13 @@ mod tests {
         );
     }
 
+    // T-048: parse_page_id — UUID でも hex32 でも URL でもない文字列はエラー
     #[test]
     fn test_parse_invalid_string() {
         assert!(parse_page_id("not-a-valid-id").is_err());
     }
 
+    // T-049: parse_page_id — notion.site サブドメイン URL から ID を抽出
     #[test]
     fn test_parse_notion_site_url() {
         let url = "https://myworkspace.notion.site/Page-123456781234123412341234567890ab";
@@ -322,6 +335,7 @@ mod tests {
         );
     }
 
+    // T-050: parse_page_id — www なし notion.so URL から ID を抽出
     #[test]
     fn test_parse_notion_url_without_www() {
         let url = "https://notion.so/Page-123456781234123412341234567890ab";
@@ -331,6 +345,7 @@ mod tests {
         );
     }
 
+    // T-051: parse_page_id — URL フラグメント付きでも ID を抽出する
     #[test]
     fn test_parse_notion_url_with_fragment() {
         let url = "https://www.notion.so/Page-123456781234123412341234567890ab#section";
@@ -340,6 +355,7 @@ mod tests {
         );
     }
 
+    // T-052: parse_page_id — パスが UUID そのものの URL から ID を抽出
     #[test]
     fn test_parse_notion_url_with_uuid_in_path() {
         let url = "https://www.notion.so/12345678-1234-1234-1234-1234567890ab";
@@ -349,6 +365,7 @@ mod tests {
         );
     }
 
+    // T-053: parse_page_id — 空文字列はエラー
     #[test]
     fn test_parse_empty_string() {
         assert!(parse_page_id("").is_err());

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,7 @@
-use std::io::{IsTerminal, Read};
+use std::{
+    io::{self, IsTerminal, Read, Write},
+    process,
+};
 
 use clap::{Parser, Subcommand};
 
@@ -57,16 +60,16 @@ enum Commands {
 
 #[tokio::main]
 async fn main() {
-    #[cfg(unix)]
-    unsafe {
-        libc::signal(libc::SIGPIPE, libc::SIG_DFL);
-    }
-
     let cli = Cli::parse();
 
     if let Err(e) = run(cli).await {
+        if let client::NotchError::Io(ref io_err) = e {
+            if io_err.kind() == io::ErrorKind::BrokenPipe {
+                process::exit(0);
+            }
+        }
         eprintln!("Error: {e}");
-        std::process::exit(1);
+        process::exit(1);
     }
 }
 
@@ -75,7 +78,7 @@ async fn run(cli: Cli) -> Result<(), client::NotchError> {
 
     match cli.command {
         Commands::Fetch { page_id_or_url } => {
-            let stdin = std::io::stdin();
+            let stdin = io::stdin();
             let page_id_or_url =
                 resolve_resource_input(page_id_or_url, stdin.lock(), stdin.is_terminal())?;
             let page_id = parse_page_id(&page_id_or_url)?;
@@ -98,7 +101,7 @@ async fn run(cli: Cli) -> Result<(), client::NotchError> {
                 eprintln!("{warning}");
             }
 
-            print!("{}", result.stdout);
+            io::stdout().write_all(result.stdout.as_bytes())?;
         }
         Commands::Search { query } => {
             let resp = client.search(&query).await?;
@@ -115,11 +118,17 @@ async fn run(cli: Cli) -> Result<(), client::NotchError> {
                 } else {
                     &title
                 };
-                println!("{}\t{}\t{}", page.id, title, page.last_edited_time);
+                writeln!(
+                    io::stdout(),
+                    "{}\t{}\t{}",
+                    page.id,
+                    title,
+                    page.last_edited_time
+                )?;
             }
         }
         Commands::Query { database_id_or_url } => {
-            let stdin = std::io::stdin();
+            let stdin = io::stdin();
             let database_id_or_url =
                 resolve_resource_input(database_id_or_url, stdin.lock(), stdin.is_terminal())?;
             let db_id = parse_page_id(&database_id_or_url)?;
@@ -145,14 +154,14 @@ async fn run(cli: Cli) -> Result<(), client::NotchError> {
             }
 
             let columns = resp.results[0].properties.sorted_names();
-            println!("id\t{}", columns.join("\t"));
+            writeln!(io::stdout(), "id\t{}", columns.join("\t"))?;
 
             for row in &resp.results {
                 let values: Vec<String> = columns
                     .iter()
                     .map(|col| row.properties.property_text(col))
                     .collect();
-                println!("{}\t{}", row.id, values.join("\t"));
+                writeln!(io::stdout(), "{}\t{}", row.id, values.join("\t"))?;
             }
         }
     }
@@ -170,7 +179,7 @@ fn resolve_resource_input(
         Some(_) => read_stdin_value(&mut stdin),
         None if stdin_is_terminal => Err(client::NotchError::InvalidInput(
             "Missing ID/URL argument. Pipe one via stdin or pass `-` to read stdin interactively"
-                .to_string(),
+                .to_owned(),
         )),
         None => read_stdin_value(&mut stdin),
     }
@@ -183,11 +192,11 @@ fn read_stdin_value(mut stdin: impl Read) -> Result<String, client::NotchError> 
     let trimmed = buffer.trim();
     if trimmed.is_empty() {
         return Err(client::NotchError::InvalidInput(
-            "No input provided. Pass an ID/URL argument or pipe one via stdin".to_string(),
+            "No input provided. Pass an ID/URL argument or pipe one via stdin".to_owned(),
         ));
     }
 
-    Ok(trimmed.to_string())
+    Ok(trimmed.to_owned())
 }
 
 #[cfg(test)]
@@ -235,6 +244,7 @@ mod tests {
         }
     }
 
+    // T-068: subcommand_help — fetch/search/query にサンプルが含まれる
     #[test]
     fn subcommand_help_includes_examples() {
         for (name, snippets) in [
@@ -252,6 +262,7 @@ mod tests {
         }
     }
 
+    // T-069: resolve_resource_input — 位置引数・パイプ stdin・"-" の各ケース
     #[test]
     fn resolve_resource_input_handles_positional_and_stdin_cases() {
         for (input, stdin, stdin_is_terminal, expected) in [
@@ -269,6 +280,7 @@ mod tests {
         }
     }
 
+    // T-070: resolve_resource_input — TTY で引数なしはエラー
     #[test]
     fn resolve_resource_input_rejects_missing_argument_on_tty() {
         let err = resolve_resource_input(None, Cursor::new(Vec::<u8>::new()), true).unwrap_err();
@@ -278,17 +290,18 @@ mod tests {
         );
     }
 
+    // T-071: resolve_resource_input — "-" で空 stdin はエラー
     #[test]
     fn resolve_resource_input_rejects_empty_stdin_with_dash() {
-        let err =
-            resolve_resource_input(Some("-".to_string()), Cursor::new(Vec::<u8>::new()), true)
-                .unwrap_err();
+        let err = resolve_resource_input(Some("-".to_owned()), Cursor::new(Vec::<u8>::new()), true)
+            .unwrap_err();
         assert_eq!(
             err.to_string(),
             "No input provided. Pass an ID/URL argument or pipe one via stdin"
         );
     }
 
+    // T-072: resolve_resource_input — パイプ stdin が空のときエラー
     #[test]
     fn resolve_resource_input_rejects_empty_piped_stdin() {
         let err = resolve_resource_input(None, Cursor::new(Vec::<u8>::new()), false).unwrap_err();
@@ -298,6 +311,7 @@ mod tests {
         );
     }
 
+    // T-073: cli — fetch/query で "-" と引数なしを正しくパースする
     #[test]
     fn cli_parses_optional_stdin_inputs() {
         assert_eq!(parse_fetch(&["notch", "fetch", "-"]).as_deref(), Some("-"));
@@ -306,6 +320,7 @@ mod tests {
         assert_eq!(parse_query(&["notch", "query"]), None);
     }
 
+    // T-074: cli — 全サブコマンドの after_help に Examples が含まれる
     #[test]
     fn all_subcommands_have_examples_in_after_help() {
         let command = Cli::command();
@@ -313,7 +328,7 @@ mod tests {
         for sub in command.get_subcommands() {
             let after_help = sub
                 .get_after_help()
-                .map(|help| help.to_string())
+                .map(ToString::to_string)
                 .unwrap_or_default();
 
             assert!(

--- a/src/markdown.rs
+++ b/src/markdown.rs
@@ -1,3 +1,5 @@
+use crate::sanitize::sanitize;
+
 const MAX_OUTPUT_BYTES: usize = 100 * 1024;
 
 pub struct FormatResult {
@@ -10,10 +12,10 @@ pub fn format_output(title: &str, markdown: &str, truncated_by_api: bool) -> For
 
     if truncated_by_api {
         warnings
-            .push("Warning: Page content was truncated by Notion API (page too large)".to_string());
+            .push("Warning: Page content was truncated by Notion API (page too large)".to_owned());
     }
 
-    let sanitized = crate::sanitize::sanitize(markdown);
+    let sanitized = sanitize(markdown);
 
     let mut output = if title.is_empty() {
         sanitized
@@ -24,7 +26,7 @@ pub fn format_output(title: &str, markdown: &str, truncated_by_api: bool) -> For
     if output.len() > MAX_OUTPUT_BYTES {
         let end = output.floor_char_boundary(MAX_OUTPUT_BYTES);
         output.truncate(end);
-        warnings.push("(truncated: output exceeded 100KB)".to_string());
+        warnings.push("(truncated: output exceeded 100KB)".to_owned());
     }
 
     FormatResult {
@@ -37,27 +39,43 @@ pub fn format_output(title: &str, markdown: &str, truncated_by_api: bool) -> For
 mod tests {
     use super::*;
 
+    // T-036: format_output — タイトルあり
     #[test]
     fn test_format_with_title() {
         let result = format_output("Test Page", "Hello world", false);
         assert_eq!(result.stdout, "# Test Page\n\nHello world");
-        assert!(result.warnings.is_empty());
+        assert!(
+            result.warnings.is_empty(),
+            "expected no warnings, got: {:?}",
+            result.warnings
+        );
     }
 
+    // T-037: format_output — タイトルなし（空文字列）
     #[test]
     fn test_format_empty_title() {
         let result = format_output("", "Hello world", false);
         assert_eq!(result.stdout, "Hello world");
-        assert!(result.warnings.is_empty());
+        assert!(
+            result.warnings.is_empty(),
+            "expected no warnings, got: {:?}",
+            result.warnings
+        );
     }
 
+    // T-038: format_output — API truncated フラグが警告メッセージになる
     #[test]
     fn test_format_api_truncated_warning() {
         let result = format_output("Title", "body", true);
         assert_eq!(result.warnings.len(), 1);
-        assert!(result.warnings[0].contains("truncated by Notion API"));
+        assert!(
+            result.warnings[0].contains("truncated by Notion API"),
+            "got: {}",
+            result.warnings[0]
+        );
     }
 
+    // T-039: format_output — 100KB 超のとき切り詰め警告を出す
     #[test]
     fn test_format_output_size_truncation() {
         let large = "a".repeat(200 * 1024); // 200KB
@@ -66,6 +84,7 @@ mod tests {
         assert!(result.warnings.iter().any(|w| w.contains("exceeded 100KB")));
     }
 
+    // T-040: format_output — 切り詰めが UTF-8 文字境界を尊重する
     #[test]
     fn test_format_output_truncation_respects_utf8_boundary() {
         let padding = "a".repeat(MAX_OUTPUT_BYTES - 10);
@@ -79,8 +98,16 @@ mod tests {
     fn test_sanitize_applies_to_body_only() {
         let result = format_output("Title {color=\"gray\"}", "<empty-block/>content", false);
         // Title should still contain {color=...} — not sanitized
-        assert!(result.stdout.contains("{color=\"gray\"}"));
+        assert!(
+            result.stdout.contains("{color=\"gray\"}"),
+            "got: {}",
+            result.stdout
+        );
         // Body should be sanitized — <empty-block/> removed
-        assert!(!result.stdout.contains("<empty-block/>"));
+        assert!(
+            !result.stdout.contains("<empty-block/>"),
+            "got: {}",
+            result.stdout
+        );
     }
 }

--- a/src/sanitize.rs
+++ b/src/sanitize.rs
@@ -70,7 +70,7 @@ fn split_code_segments(input: &str) -> Vec<Segment<'_>> {
 
 /// Sanitize non-code text segments.
 fn sanitize_text(input: &str) -> String {
-    let mut s = input.to_string();
+    let mut s = input.to_owned();
 
     // Table conversion must run first: it produces markdown that later
     // steps (span stripping, br removal) would otherwise miss inside cells.
@@ -114,7 +114,7 @@ fn replace_tag(s: &mut String, tag_name: &str, replacement: impl Fn(&str) -> Str
         let Some(end) = find_tag_end(s, start, tag_name) else {
             break;
         };
-        let tag = s[start..end].to_string();
+        let tag = s[start..end].to_owned();
         let repl = replacement(&tag);
         let repl_len = repl.len();
         s.replace_range(start..end, &repl);
@@ -128,8 +128,8 @@ fn convert_mentions_mut(s: &mut String) {
         let url = extract_attr(tag, "url").unwrap_or_default();
         format!("[Notion page]({url})")
     });
-    replace_tag(s, "mention-user", |_| "@user".to_string());
-    replace_tag(s, "file", |_| "[attachment]".to_string());
+    replace_tag(s, "mention-user", |_| "@user".to_owned());
+    replace_tag(s, "file", |_| "[attachment]".to_owned());
 }
 
 /// Find the end position (exclusive) of a tag, handling self-closing and paired tags.
@@ -160,7 +160,7 @@ fn extract_attr(tag: &str, attr: &str) -> Option<String> {
     let start = tag.find(&pattern)?;
     let value_start = start + pattern.len();
     let value_end = tag[value_start..].find('"')?;
-    Some(tag[value_start..value_start + value_end].to_string())
+    Some(tag[value_start..value_start + value_end].to_owned())
 }
 
 /// Strip <span color="...">text</span> → text, in-place.
@@ -172,7 +172,7 @@ fn strip_span_tags_mut(s: &mut String) {
         let tag_end = start + gt + 1;
 
         if let Some(close) = s[tag_end..].find("</span>") {
-            let content = s[tag_end..tag_end + close].to_string();
+            let content = s[tag_end..tag_end + close].to_owned();
             s.replace_range(start..tag_end + close + 7, &content);
         } else {
             s.replace_range(start..tag_end, "");
@@ -203,7 +203,7 @@ fn strip_curly_from_line(line: &str) -> Cow<'_, str> {
     if let Some(brace_start) = trimmed.rfind('{') {
         let after_brace = &trimmed[brace_start..];
         if after_brace.ends_with('}') && after_brace.contains('=') {
-            return Cow::Owned(trimmed[..brace_start].trim_end().to_string());
+            return Cow::Owned(trimmed[..brace_start].trim_end().to_owned());
         }
     }
     Cow::Borrowed(line)
@@ -292,7 +292,7 @@ fn parse_table_rows(html: &str) -> Vec<Vec<String>> {
 
 /// Render a 2D string grid as a Markdown pipe table.
 fn render_pipe_table(rows: &[Vec<String>]) -> String {
-    let col_count = rows.iter().map(|r| r.len()).max().unwrap_or(0);
+    let col_count = rows.iter().map(Vec::len).max().unwrap_or(0);
     let mut lines = Vec::with_capacity(rows.len() + 1);
 
     for (i, row) in rows.iter().enumerate() {
@@ -315,7 +315,7 @@ fn remove_colgroup(html: &str) -> Cow<'_, str> {
     if !html.contains("<colgroup>") {
         return Cow::Borrowed(html);
     }
-    let mut s = html.to_string();
+    let mut s = html.to_owned();
     while let Some(start) = s.find("<colgroup>") {
         if let Some(end) = s[start..].find("</colgroup>") {
             s.replace_range(start..start + end + 11, "");
@@ -353,10 +353,10 @@ fn clean_cell_content(content: &str) -> String {
     let trimmed = content.trim();
     // Fast path: no special markers
     if !trimmed.contains('<') && !trimmed.contains('|') {
-        return trimmed.to_string();
+        return trimmed.to_owned();
     }
 
-    let mut s = trimmed.to_string();
+    let mut s = trimmed.to_owned();
     if s.contains("<span ") {
         strip_span_tags_mut(&mut s);
     }
@@ -367,7 +367,7 @@ fn clean_cell_content(content: &str) -> String {
     if s.contains('|') {
         s = s.replace('|', r"\|");
     }
-    s.trim().to_string()
+    s.trim().to_owned()
 }
 
 /// Strip <details>/<summary> tags, converting to **summary** + content.
@@ -429,7 +429,7 @@ fn convert_details_content(inner: &str) -> String {
         }
     }
     // No summary — just return content
-    trimmed.to_string()
+    trimmed.to_owned()
 }
 
 /// Strip <callout> tags, extracting icon attribute if present.
@@ -449,7 +449,7 @@ fn strip_callout_mut(s: &mut String) {
         let content = s[content_start..content_start + close_offset].trim();
         let replacement = match icon {
             Some(i) => format!("{i} {content}"),
-            None => content.to_string(),
+            None => content.to_owned(),
         };
         let end = content_start + close_offset + 10;
         s.replace_range(start..end, &replacement);
@@ -472,7 +472,7 @@ fn strip_wrapper_tag_mut(s: &mut String, tag: &str) {
         };
         let content = s[content_start..content_start + close_offset]
             .trim()
-            .to_string();
+            .to_owned();
         let end = content_start + close_offset + close.len();
         s.replace_range(start..end, &content);
     }
@@ -520,7 +520,7 @@ fn extract_columns(html: &str) -> Vec<String> {
     while let Some(col_start) = remaining.find("<column>") {
         let after = &remaining[col_start + 8..]; // 8 = "<column>".len()
         if let Some(col_end) = after.find("</column>") {
-            columns.push(after[..col_end].trim().to_string());
+            columns.push(after[..col_end].trim().to_owned());
             remaining = &after[col_end + 9..]; // 9 = "</column>".len()
         } else {
             break;
@@ -534,9 +534,9 @@ fn convert_checkboxes_mut(s: &mut String) {
     replace_tag(s, "checkbox", |tag| {
         let checked = extract_attr(tag, "checked").unwrap_or_default();
         if checked == "true" {
-            "[x] ".to_string()
+            "[x] ".to_owned()
         } else {
-            "[ ] ".to_string()
+            "[ ] ".to_owned()
         }
     });
 }
@@ -679,9 +679,9 @@ mod tests {
     fn test_basic_table_conversion() {
         let input = "<table>\n<tr>\n<td>A</td>\n<td>B</td>\n</tr>\n<tr>\n<td>1</td>\n<td>2</td>\n</tr>\n</table>";
         let result = sanitize(input);
-        assert!(result.contains("| A | B |"));
-        assert!(result.contains("| --- | --- |"));
-        assert!(result.contains("| 1 | 2 |"));
+        assert!(result.contains("| A | B |"), "got: {result}");
+        assert!(result.contains("| --- | --- |"), "got: {result}");
+        assert!(result.contains("| 1 | 2 |"), "got: {result}");
     }
 
     // T-013: FR-011 — テーブルセル内パイプエスケープ
@@ -689,7 +689,7 @@ mod tests {
     fn test_table_cell_pipe_escaped() {
         let input = "<table>\n<tr>\n<td>H</td>\n</tr>\n<tr>\n<td>a|b</td>\n</tr>\n</table>";
         let result = sanitize(input);
-        assert!(result.contains(r"a\|b"));
+        assert!(result.contains(r"a\|b"), "got: {result}");
     }
 
     // T-014: FR-012 — テーブルセル内 br 除去
@@ -697,7 +697,7 @@ mod tests {
     fn test_table_cell_br_removed() {
         let input = "<table>\n<tr>\n<td>H</td>\n</tr>\n<tr>\n<td>a<br>b</td>\n</tr>\n</table>";
         let result = sanitize(input);
-        assert!(result.contains("a b"));
+        assert!(result.contains("a b"), "got: {result}");
     }
 
     // T-015: FR-013 — テーブルセル内 span 除去
@@ -705,7 +705,7 @@ mod tests {
     fn test_table_cell_span_removed() {
         let input = "<table>\n<tr>\n<td>H</td>\n</tr>\n<tr>\n<td><span color=\"red\">x</span></td>\n</tr>\n</table>";
         let result = sanitize(input);
-        assert!(result.contains("| x |"));
+        assert!(result.contains("| x |"), "got: {result}");
     }
 
     // T-016: FR-010 — テーブル内 colgroup 除去
@@ -713,8 +713,8 @@ mod tests {
     fn test_table_colgroup_removed() {
         let input = "<table>\n<colgroup>\n<col>\n<col>\n</colgroup>\n<tr>\n<td>A</td>\n<td>B</td>\n</tr>\n</table>";
         let result = sanitize(input);
-        assert!(result.contains("| A | B |"));
-        assert!(!result.contains("colgroup"));
+        assert!(result.contains("| A | B |"), "got: {result}");
+        assert!(!result.contains("colgroup"), "got: {result}");
     }
 
     // T-017: FR-010 — テーブルセル属性除去
@@ -722,15 +722,15 @@ mod tests {
     fn test_table_cell_attribute_removed() {
         let input = "<table>\n<tr>\n<td color=\"yellow_bg\">text</td>\n</tr>\n</table>";
         let result = sanitize(input);
-        assert!(result.contains("| text |"));
+        assert!(result.contains("| text |"), "got: {result}");
     }
 
     // T-018: FR-010 — 空テーブル
     #[test]
     fn test_empty_table() {
         let result = sanitize("<table>\n</table>");
-        assert!(!result.contains("table"));
-        assert!(result.trim().is_empty());
+        assert!(!result.contains("table"), "got: {result}");
+        assert!(result.trim().is_empty(), "got: {result:?}");
     }
 
     // T-019: FR-010 — 1列テーブル
@@ -738,9 +738,9 @@ mod tests {
     fn test_single_column_table() {
         let input = "<table>\n<tr>\n<td>H</td>\n</tr>\n<tr>\n<td>V</td>\n</tr>\n</table>";
         let result = sanitize(input);
-        assert!(result.contains("| H |"));
-        assert!(result.contains("| --- |"));
-        assert!(result.contains("| V |"));
+        assert!(result.contains("| H |"), "got: {result}");
+        assert!(result.contains("| --- |"), "got: {result}");
+        assert!(result.contains("| V |"), "got: {result}");
     }
 
     // T-020: FR-014 — コードブロック内保護
@@ -748,8 +748,8 @@ mod tests {
     fn test_code_block_preserved() {
         let input = "before\n```\n{color=\"red\"}\n<empty-block/>\n```\nafter";
         let result = sanitize(input);
-        assert!(result.contains("{color=\"red\"}"));
-        assert!(result.contains("<empty-block/>"));
+        assert!(result.contains("{color=\"red\"}"), "got: {result}");
+        assert!(result.contains("<empty-block/>"), "got: {result}");
     }
 
     // T-021: FR-015 — インラインコード内保護
@@ -757,7 +757,7 @@ mod tests {
     fn test_inline_code_preserved() {
         let input = "use `<empty-block/>` tag";
         let result = sanitize(input);
-        assert!(result.contains("`<empty-block/>`"));
+        assert!(result.contains("`<empty-block/>`"), "got: {result}");
     }
 
     // T-022: FR-016 — 連続空行の正規化
@@ -778,7 +778,7 @@ mod tests {
     fn test_malformed_tag_survives() {
         let input = "<span color=\"red\">no close";
         let result = sanitize(input);
-        assert!(result.contains("no close"));
+        assert!(result.contains("no close"), "got: {result}");
     }
 
     // T-025: ALL — 複合パターン
@@ -793,13 +793,16 @@ mod tests {
             "<empty-block/>"
         );
         let result = sanitize(input);
-        assert!(!result.contains("{color="));
-        assert!(result.contains("[Notion page](https://notion.so/page1)"));
-        assert!(result.contains("warning"));
-        assert!(!result.contains("<span"));
-        assert!(result.contains("| Col |"));
-        assert!(!result.contains("X-Amz-Algorithm"));
-        assert!(!result.contains("<empty-block/>"));
+        assert!(!result.contains("{color="), "got: {result}");
+        assert!(
+            result.contains("[Notion page](https://notion.so/page1)"),
+            "got: {result}"
+        );
+        assert!(result.contains("warning"), "got: {result}");
+        assert!(!result.contains("<span"), "got: {result}");
+        assert!(result.contains("| Col |"), "got: {result}");
+        assert!(!result.contains("X-Amz-Algorithm"), "got: {result}");
+        assert!(!result.contains("<empty-block/>"), "got: {result}");
     }
 
     // === v2: LLM コンテキスト最適化 ===
@@ -825,10 +828,10 @@ mod tests {
         let input =
             "<details><summary>外</summary><details><summary>内</summary>X</details></details>";
         let result = sanitize(input);
-        assert!(result.contains("**外**"));
-        assert!(result.contains("**内**"));
-        assert!(result.contains("X"));
-        assert!(!result.contains("<details"));
+        assert!(result.contains("**外**"), "got: {result}");
+        assert!(result.contains("**内**"), "got: {result}");
+        assert!(result.contains("X"), "got: {result}");
+        assert!(!result.contains("<details"), "got: {result}");
     }
 
     // T-030: FR-019 — details マルチラインコンテンツ
@@ -836,10 +839,10 @@ mod tests {
     fn test_details_multiline() {
         let input = "<details>\n<summary>タイトル</summary>\n\n- item1\n- item2\n\n</details>";
         let result = sanitize(input);
-        assert!(result.contains("**タイトル**"));
-        assert!(result.contains("- item1"));
-        assert!(result.contains("- item2"));
-        assert!(!result.contains("<details"));
+        assert!(result.contains("**タイトル**"), "got: {result}");
+        assert!(result.contains("- item1"), "got: {result}");
+        assert!(result.contains("- item2"), "got: {result}");
+        assert!(!result.contains("<details"), "got: {result}");
     }
 
     // T-031: FR-022 — callout を icon + 中身に変換
@@ -938,8 +941,8 @@ mod tests {
     fn test_code_block_preserves_v2_tags() {
         let input = "```\n<checkbox checked=\"true\"/>\n<callout icon=\"💡\">test</callout>\n```";
         let result = sanitize(input);
-        assert!(result.contains("<checkbox"));
-        assert!(result.contains("<callout"));
+        assert!(result.contains("<checkbox"), "got: {result}");
+        assert!(result.contains("<callout"), "got: {result}");
     }
 
     // T-043: FR-034 — details 内に table がある複合パターン
@@ -948,10 +951,10 @@ mod tests {
         let input =
             "<details><summary>T</summary>\n<table>\n<tr>\n<td>A</td>\n</tr>\n</table>\n</details>";
         let result = sanitize(input);
-        assert!(result.contains("**T**"));
-        assert!(result.contains("| A |"));
-        assert!(!result.contains("<details"));
-        assert!(!result.contains("<table"));
+        assert!(result.contains("**T**"), "got: {result}");
+        assert!(result.contains("| A |"), "got: {result}");
+        assert!(!result.contains("<details"), "got: {result}");
+        assert!(!result.contains("<table"), "got: {result}");
     }
 
     // T-044: ALL — v1+v2 全混合複合パターン
@@ -968,17 +971,23 @@ mod tests {
             "<bookmark url=\"https://example.com\">リンク</bookmark>"
         );
         let result = sanitize(input);
-        assert!(!result.contains("{color="));
-        assert!(result.contains("**詳細**"));
-        assert!(result.contains("💡 重要"));
-        assert!(result.contains("[x] タスク"));
-        assert!(result.contains("$E=mc^2$"));
-        assert!(result.contains("[Notion page](https://notion.so/page1)"));
-        assert!(result.contains("[リンク](https://example.com)"));
-        assert!(!result.contains("<details"));
-        assert!(!result.contains("<callout"));
-        assert!(!result.contains("<checkbox"));
-        assert!(!result.contains("<equation"));
-        assert!(!result.contains("<bookmark"));
+        assert!(!result.contains("{color="), "got: {result}");
+        assert!(result.contains("**詳細**"), "got: {result}");
+        assert!(result.contains("💡 重要"), "got: {result}");
+        assert!(result.contains("[x] タスク"), "got: {result}");
+        assert!(result.contains("$E=mc^2$"), "got: {result}");
+        assert!(
+            result.contains("[Notion page](https://notion.so/page1)"),
+            "got: {result}"
+        );
+        assert!(
+            result.contains("[リンク](https://example.com)"),
+            "got: {result}"
+        );
+        assert!(!result.contains("<details"), "got: {result}");
+        assert!(!result.contains("<callout"), "got: {result}");
+        assert!(!result.contains("<checkbox"), "got: {result}");
+        assert!(!result.contains("<equation"), "got: {result}");
+        assert!(!result.contains("<bookmark"), "got: {result}");
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -49,7 +49,7 @@ impl PageProperties {
                 .and_then(|s| s.get("name"))
                 .and_then(|n| n.as_str())
                 .unwrap_or_default()
-                .to_string(),
+                .to_owned(),
             "multi_select" => value
                 .get("multi_select")
                 .and_then(|a| a.as_array())
@@ -69,12 +69,12 @@ impl PageProperties {
                 let end = date.and_then(|d| d.get("end")).and_then(|e| e.as_str());
                 match end {
                     Some(e) => format!("{start} → {e}"),
-                    None => start.to_string(),
+                    None => start.to_owned(),
                 }
             }
             "checkbox" => value
                 .get("checkbox")
-                .and_then(|c| c.as_bool())
+                .and_then(serde_json::Value::as_bool)
                 .map(|b| b.to_string())
                 .unwrap_or_default(),
             "url" => extract_string_field(value, "url"),
@@ -98,10 +98,10 @@ impl PageProperties {
         others.sort_unstable();
         let mut result = Vec::with_capacity(self.0.len());
         if let Some(title) = title_key {
-            result.push(title.to_string());
+            result.push(title.to_owned());
         }
         for key in others {
-            result.push(key.to_string());
+            result.push(key.to_owned());
         }
         result
     }
@@ -124,17 +124,19 @@ fn extract_string_field(value: &serde_json::Value, field: &str) -> String {
         .get(field)
         .and_then(|s| s.as_str())
         .unwrap_or_default()
-        .to_string()
+        .to_owned()
 }
 
 fn sanitize_value(s: &str) -> String {
     if s.contains(['\t', '\n', '\r']) {
         s.replace(['\t', '\n', '\r'], " ")
     } else {
-        s.to_string()
+        s.to_owned()
     }
 }
 
+// Range-checked above: `(i64::MIN as f64..=i64::MAX as f64).contains(&n)` ensures n fits in i64
+#[allow(clippy::cast_possible_truncation)]
 fn format_number(n: f64) -> String {
     if n.fract() == 0.0 && (i64::MIN as f64..=i64::MAX as f64).contains(&n) {
         (n as i64).to_string()
@@ -189,5 +191,4 @@ pub struct NotionErrorResponse {
 }
 
 #[cfg(test)]
-#[path = "types_tests.rs"]
 mod tests;

--- a/src/types/tests.rs
+++ b/src/types/tests.rs
@@ -1,11 +1,13 @@
 use super::*;
 
+// T-031: title_text — プロパティが空のとき空文字列を返す
 #[test]
 fn test_title_text_empty_properties() {
     let props: PageProperties = serde_json::from_str("{}").unwrap();
     assert_eq!(props.title_text(), "");
 }
 
+// T-032: title_text — title type を持つプロパティがないとき空文字列
 #[test]
 fn test_title_text_no_title_type() {
     let props: PageProperties =
@@ -13,6 +15,7 @@ fn test_title_text_no_title_type() {
     assert_eq!(props.title_text(), "");
 }
 
+// T-033: title_text — カスタムキー名でも title type を検出する
 #[test]
 fn test_title_text_with_custom_name() {
     let json = r#"{"Name": {"type": "title", "title": [{"plain_text": "My Page"}]}}"#;
@@ -20,6 +23,7 @@ fn test_title_text_with_custom_name() {
     assert_eq!(props.title_text(), "My Page");
 }
 
+// T-034: title_text — 複数セグメントを結合する
 #[test]
 fn test_title_text_multi_segment() {
     let json = r#"{"Title": {"type": "title", "title": [{"plain_text": "Hello "}, {"plain_text": "World"}]}}"#;
@@ -157,7 +161,7 @@ fn test_property_text_unsupported_type() {
     assert_eq!(props.property_text("Calc"), "");
 }
 
-// T-020 supplement: 存在しないキー
+// T-035: property_text — 存在しないキーは空文字列を返す
 #[test]
 fn test_property_text_missing_key() {
     let props: PageProperties = serde_json::from_str("{}").unwrap();
@@ -178,7 +182,11 @@ fn test_database_response_deserialize() {
 fn test_database_response_empty_data_sources() {
     let json = r#"{"data_sources": []}"#;
     let resp: DatabaseResponse = serde_json::from_str(json).unwrap();
-    assert!(resp.data_sources.is_empty());
+    assert!(
+        resp.data_sources.is_empty(),
+        "expected empty, got: {:?}",
+        resp.data_sources
+    );
 }
 
 // T-003 prep: DataSourceQueryResponse デシリアライズ

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -4,9 +4,10 @@ use wiremock::{Mock, MockServer, ResponseTemplate};
 use notch::client::{Client, NotchError};
 
 fn test_client(base_url: &str) -> Client {
-    Client::with_token("test-token".into(), format!("{base_url}/v1")).unwrap()
+    Client::with_token("test-token", format!("{base_url}/v1")).unwrap()
 }
 
+// T-054: fetch_markdown — 200 OK のとき markdown を返す
 #[tokio::test]
 async fn test_fetch_markdown_success() {
     let server = MockServer::start().await;
@@ -29,6 +30,7 @@ async fn test_fetch_markdown_success() {
     assert!(!resp.truncated);
 }
 
+// T-055: fetch_markdown — truncated=true と unknown_block_ids を返す
 #[tokio::test]
 async fn test_fetch_markdown_truncated() {
     let server = MockServer::start().await;
@@ -50,6 +52,7 @@ async fn test_fetch_markdown_truncated() {
     assert_eq!(resp.unknown_block_ids, vec!["block-1"]);
 }
 
+// T-056: fetch_metadata — title プロパティを複数セグメントから結合する
 #[tokio::test]
 async fn test_fetch_metadata_title_extraction() {
     let server = MockServer::start().await;
@@ -77,6 +80,7 @@ async fn test_fetch_metadata_title_extraction() {
     assert_eq!(meta.properties.title_text(), "My Page");
 }
 
+// T-057: fetch_markdown — 404 は NotFoundOrForbidden を返す
 #[tokio::test]
 async fn test_fetch_404_returns_not_found() {
     let server = MockServer::start().await;
@@ -94,9 +98,13 @@ async fn test_fetch_404_returns_not_found() {
     let client = test_client(&server.uri());
     let err = client.fetch_markdown("missing-id").await.unwrap_err();
 
-    assert!(matches!(err, NotchError::NotFoundOrForbidden));
+    assert!(
+        matches!(err, NotchError::NotFoundOrForbidden),
+        "got: {err:?}"
+    );
 }
 
+// T-058: fetch_markdown — 403 は NotFoundOrForbidden を返す
 #[tokio::test]
 async fn test_fetch_403_returns_not_found() {
     let server = MockServer::start().await;
@@ -114,9 +122,13 @@ async fn test_fetch_403_returns_not_found() {
     let client = test_client(&server.uri());
     let err = client.fetch_markdown("forbidden-id").await.unwrap_err();
 
-    assert!(matches!(err, NotchError::NotFoundOrForbidden));
+    assert!(
+        matches!(err, NotchError::NotFoundOrForbidden),
+        "got: {err:?}"
+    );
 }
 
+// T-059: fetch_markdown — 429 は RateLimited を返す（リトライ後）
 #[tokio::test]
 async fn test_fetch_429_returns_rate_limited() {
     let server = MockServer::start().await;
@@ -138,9 +150,10 @@ async fn test_fetch_429_returns_rate_limited() {
     let client = test_client(&server.uri());
     let err = client.fetch_markdown("any-id").await.unwrap_err();
 
-    assert!(matches!(err, NotchError::RateLimited));
+    assert!(matches!(err, NotchError::RateLimited), "got: {err:?}");
 }
 
+// T-060: search — 検索結果のページリストを返す
 #[tokio::test]
 async fn test_search_returns_pages() {
     let server = MockServer::start().await;
@@ -175,6 +188,7 @@ async fn test_search_returns_pages() {
     assert_eq!(resp.results[0].last_edited_time, "2026-03-13T10:00:00.000Z");
 }
 
+// T-061: search — リクエストに page フィルターが含まれる
 #[tokio::test]
 async fn test_search_sends_page_filter() {
     let server = MockServer::start().await;
@@ -197,9 +211,14 @@ async fn test_search_sends_page_filter() {
 
     let client = test_client(&server.uri());
     let resp = client.search("anything").await.unwrap();
-    assert!(resp.results.is_empty());
+    assert!(
+        resp.results.is_empty(),
+        "expected empty, got: {:?}",
+        resp.results
+    );
 }
 
+// T-062: fetch_markdown — 500 は Api エラーを返す
 #[tokio::test]
 async fn test_fetch_500_returns_api_error() {
     let server = MockServer::start().await;
@@ -217,9 +236,13 @@ async fn test_fetch_500_returns_api_error() {
     let client = test_client(&server.uri());
     let err = client.fetch_markdown("error-id").await.unwrap_err();
 
-    assert!(matches!(err, NotchError::Api { status: 500, .. }));
+    assert!(
+        matches!(err, NotchError::Api { status: 500, .. }),
+        "got: {err:?}"
+    );
 }
 
+// T-063: fetch_markdown — 502 + HTML ボディのとき "HTTP 502" にフォールバック
 #[tokio::test]
 async fn test_fetch_502_html_body_fallback() {
     let server = MockServer::start().await;
@@ -242,6 +265,7 @@ async fn test_fetch_502_html_body_fallback() {
     }
 }
 
+// T-064: fetch_markdown — 200 + 不正 JSON は Http エラーを返す
 #[tokio::test]
 async fn test_fetch_200_malformed_json() {
     let server = MockServer::start().await;
@@ -255,9 +279,10 @@ async fn test_fetch_200_malformed_json() {
     let client = test_client(&server.uri());
     let err = client.fetch_markdown("broken").await.unwrap_err();
 
-    assert!(matches!(err, NotchError::Http(_)));
+    assert!(matches!(err, NotchError::Http(_)), "got: {err:?}");
 }
 
+// T-065: search — 400 は Api エラーを返す
 #[tokio::test]
 async fn test_search_error_returns_api_error() {
     let server = MockServer::start().await;
@@ -275,9 +300,13 @@ async fn test_search_error_returns_api_error() {
     let client = test_client(&server.uri());
     let err = client.search("test").await.unwrap_err();
 
-    assert!(matches!(err, NotchError::Api { status: 400, .. }));
+    assert!(
+        matches!(err, NotchError::Api { status: 400, .. }),
+        "got: {err:?}"
+    );
 }
 
+// T-066: fetch_metadata — 404 は NotFoundOrForbidden を返す
 #[tokio::test]
 async fn test_fetch_metadata_404_returns_not_found() {
     let server = MockServer::start().await;
@@ -295,9 +324,13 @@ async fn test_fetch_metadata_404_returns_not_found() {
     let client = test_client(&server.uri());
     let err = client.fetch_metadata("missing-id").await.unwrap_err();
 
-    assert!(matches!(err, NotchError::NotFoundOrForbidden));
+    assert!(
+        matches!(err, NotchError::NotFoundOrForbidden),
+        "got: {err:?}"
+    );
 }
 
+// T-067: fetch_markdown — 429 後にリトライして成功する
 #[tokio::test]
 async fn test_fetch_retries_on_429_then_succeeds() {
     let server = MockServer::start().await;
@@ -367,7 +400,10 @@ async fn test_retrieve_database_404() {
     let client = test_client(&server.uri());
     let err = client.retrieve_database("missing-db").await.unwrap_err();
 
-    assert!(matches!(err, NotchError::NotFoundOrForbidden));
+    assert!(
+        matches!(err, NotchError::NotFoundOrForbidden),
+        "got: {err:?}"
+    );
 }
 
 // T-003: FR-003 — query_data_source が行を返す
@@ -421,7 +457,11 @@ async fn test_query_data_source_empty_results() {
     let client = test_client(&server.uri());
     let resp = client.query_data_source("ds-empty").await.unwrap();
 
-    assert!(resp.results.is_empty());
+    assert!(
+        resp.results.is_empty(),
+        "expected empty, got: {:?}",
+        resp.results
+    );
 }
 
 // T-025: FR-001 — E2E: retrieve DB → query data source → TSV 検証


### PR DESCRIPTION
## 概要と目的

Clippy deny ルール 13 件と `forbid(unsafe_code)` を導入し、コードの安全性・一貫性を静的に保証する。
libc を用いた unsafe な SIGPIPE ハンドラを除去し、cargo-deny で依存関係の脆弱性・ライセンス・禁止クレートを CI で継続監査できるようにした。

## 変更内容

- **Cargo.toml**: `forbid(unsafe_code)` と 13 件の Clippy deny ルールを追加、libc 依存を削除
- **src/main.rs**: libc SIGPIPE ハンドラを削除し、`write_all`/`writeln!` による安全な BrokenPipe 処理に置き換え
- **src/client.rs / markdown.rs / sanitize.rs / types.rs**: `.to_string()` → `.to_owned()`、メソッド参照への統一、冗長クロージャ除去
- **.github/workflows/ci.yml**: cargo-deny security ジョブを追加、cargo-audit を削除（重複）
- **deny.toml**: cargo-deny 設定ファイルを新規追加
- **テストファイル再編**: `src/types_tests.rs → src/types/tests.rs`、`tests/api_test.rs → tests/cli_integration.rs`、テスト ID T-036〜T-074 付与

## 設計判断

- **safe BrokenPipe over libc::signal**: 唯一の unsafe ブロックと libc 依存を同時に除去できる。`write_all`/`writeln!` は `io::Error` を返すため、`print!` のパニックと異なりエラーが上位に伝播する
- **cargo-deny のみ（cargo-audit 廃止）**: cargo-deny は同じ RustSec DB で advisories を網羅しつつ、licenses・bans も一括管理できるため重複を排除
- **.to_owned() 統一**: `str_to_string` lint により `&str` のコピーセマンティクスと `Display` 経由の変換を区別して明示する

## テスト方法

1. `cargo clippy -- -D warnings` が警告なしで通過することを確認
2. `cargo deny check` が advisories / licenses / bans すべてグリーンになることを確認
3. `cargo test` で T-036〜T-074 を含む全テストがパスすることを確認
4. `echo test | cargo run -- - 2>&1 | head -1` などでパイプ接続時に BrokenPipe パニックが発生しないことを確認