### PR TITLE
tokio バンプと Rust 1.95 MSRV 明示

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1440,9 +1440,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.0"
+version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a91135f59b1cbf38c91e73cf3386fca9bb77915c45ce2771460c9d92f0f3d776"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
  "bytes",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "notch"
 version = "0.5.0"
 edition = "2021"
+rust-version = "1.95"
 description = "Notion Page to Markdown CLI"
 license = "MIT"
 repository = "https://github.com/thkt/notch"

--- a/src/main.rs
+++ b/src/main.rs
@@ -271,7 +271,7 @@ mod tests {
             (None, "abc123\n", false, "abc123"),
         ] {
             let value = resolve_resource_input(
-                input.map(str::to_string),
+                input.map(str::to_owned),
                 Cursor::new(stdin.as_bytes()),
                 stdin_is_terminal,
             )


### PR DESCRIPTION
## 背景と目的

依存クレート tokio のパッチ更新と、Rust 1.95 を MSRV (Minimum Supported Rust Version) として明示する。
MSRV 明示により、古い rustc でのビルド失敗が明確なエラーで弾かれるようになる。

## 変更内容

- `Cargo.lock`: tokio 1.52.0 → 1.52.1（`Cargo.toml` の semver 範囲 `^1.50.0` の範囲内）
- `Cargo.toml`: `rust-version = "1.95"` を追加（MSRV 明示）
- `src/main.rs:274`: `str::to_string` → `str::to_owned`（1.95 の clippy `str_to_string` lint 対応）

## スコープ

- **対象外**: CI の toolchain 固定はしない。`stable` 追随を維持（セキュリティパッチへの追随性優先）
- **対象外**: edition 2024 への移行（独立案件として別 PR へ）

## 検証手順

1. `cargo build` — ビルド成功を確認
2. `cargo test` — unit 7件・integration 19件がすべて pass することを確認
3. `cargo clippy --all-targets -- -D warnings` — warning 0件を確認